### PR TITLE
add a parameter to specify the IP which is exported to postgresql server...

### DIFF
--- a/manifests/autoconfigure.pp
+++ b/manifests/autoconfigure.pp
@@ -37,7 +37,8 @@
 # Copyright 2012-2014 2ndQuadrant Italia (Devise.IT SRL)
 #
 class barman::autoconfigure (
-  $host_group     = $::barman::settings::host_group,
+  $host_group         = $::barman::settings::host_group,
+  $exported_ipaddress = $::ipaddress,
 ) {
 
   # create the (empty) .pgpass file
@@ -95,7 +96,7 @@ class barman::autoconfigure (
     type        => 'host',
     database    => $barman::settings::dbname,
     user        => $barman::settings::dbuser,
-    address     => "${::ipaddress_eth1}/32",
+    address     => "${::exported_ipaddress}/32",
     auth_method => 'md5',
     tag         => "barman-${host_group}",
   }


### PR DESCRIPTION
Allow to specify the IP which will be exported to remote postgresql servers.
Default it to $::ipaddress rather than ipaddress_eth1 because on servers without eth1 this breaks remote postgresql servers collecting this resource
