### PR TITLE
Confine barman_key and postgres_key facts to Linux

### DIFF
--- a/lib/facter/barman_key.rb
+++ b/lib/facter/barman_key.rb
@@ -20,12 +20,14 @@ end
 
 
 Facter.add('barman_key') do
+  confine :kernel => 'Linux'
   setcode do
     safe_keygen_and_return('barman')
   end
 end
 
 Facter.add('postgres_key') do
+  confine :kernel => 'Linux'
   setcode do
     safe_keygen_and_return('postgres')
   end


### PR DESCRIPTION
The fact tries to create ssh keys on Solaris 11 but fails as /etc/passwd reports
the home directory of postgres as '/'. As this module currently only supports
Linux, this is a quick fix for issue #27.