### PR TITLE
Fix duplicate parameters in barman::settings

### DIFF
--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -59,8 +59,6 @@ class barman::settings (
   $post_archive_script     = false,
   $basebackup_retry_times  = false,
   $basebackup_retry_sleep  = false,
-  $pre_backup_script       = false,
-  $post_backup_script      = false,
   $backup_options          = 'exclusive_backup',
   $minimum_redundancy      = '0',
   $last_backup_maximum_age = false,


### PR DESCRIPTION
Puppet 4 complains:
Error: The parameter pre_backup_script is declared more than once in the
  parameter list at .../modules/barman/manifests/settings.pp:62:3
Error: The parameter post_backup_script is declared more than once in the
  parameter list at .../modules/barman/manifests/settings.pp:63:3