### PR TITLE
Making description validation regex more permissive

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -246,7 +246,7 @@ define barman::server (
   validate_re($backup_options, [ '^exclusive_backup$', '^concurrent_backup$', 'Invalid backup option please use exclusive_backup or concurrent_backup' ])
 
   # check if 'description' has been correctly configured
-  validate_re($name, '^[0-9a-z\-/]*$', "${name} is not a valid name. Please only use lowercase letters, numbers, slashes and hyphens.")
+  validate_re($name, '^[0-9a-z_\-/]*$', "${name} is not a valid name. Please only use lowercase letters, numbers, slashes, underscores and hyphens.")
 
   # check if immediate checkpoint is a boolean
   validate_bool($immediate_checkpoint)


### PR DESCRIPTION
Making validation regular expression for "description" allow "_"s. I see nothing in the barman documentation that disallows underscores in the name, nor do I see anything in the INI standard that disallows underscores in section headers, and lastly barman works just fine with them (we were trying to puppetize our existing configuration).