### PR TITLE
export/collectd barman and postgres ssh host keys

### DIFF
--- a/manifests/autoconfigure.pp
+++ b/manifests/autoconfigure.pp
@@ -69,12 +69,25 @@ class barman::autoconfigure (
     require => Class['barman'],
   }
 
+  Sshkey <<| tag == "barman-${host_group}-postgresql" |>> {
+    require => Class['barman'],
+  }
+
   ############## Export resources to Postgres Servers
 
   # export the archive command
   @@barman::archive_command { $::barman::barman_fqdn :
     tag         => "barman-${host_group}",
     barman_home => $barman::home,
+  }
+
+  @@sshkey { "barman-${::fqdn}":
+    ensure       => present,
+    host_aliases => [$::hostname, $::fqdn, $::ipaddress],
+    key          => $::sshecdsakey,
+    type         => 'ecdsa-sha2-nistp256',
+    target       => '/var/lib/postgresql/.ssh/known_hosts',
+    tag          => "barman-${host_group}",
   }
 
   # export the 'barman' SSH key - create if not present

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -418,6 +418,21 @@ class barman (
     require => Package['barman']
   }
 
+  file { "${home}/.ssh":
+    ensure  => directory,
+    owner   => $user,
+    group   => $group,
+    mode    => '0700',
+    require => File[$home],
+  }
+
+  file { "${home}/.ssh/known_hosts":
+    ensure => present,
+    owner  => $user,
+    group  => $group,
+    mode   => '0600',
+  }
+
   # Run 'barman check all' to create Barman backup directories
   exec { 'barman-check-all':
     command     => '/usr/bin/barman check all',

--- a/manifests/postgres.pp
+++ b/manifests/postgres.pp
@@ -389,6 +389,15 @@ class barman::postgres (
     }
   }
 
+  @@sshkey { "postgres-${::hostname}":
+    ensure       => present,
+    host_aliases => [$::hostname, $::fqdn, $::ipaddress],
+    key          => $::sshecdsakey,
+    type         => 'ecdsa-sha2-nistp256',
+    target       => "${barman_home}/.ssh/known_hosts",
+    tag          => "barman-${host_group}-postgresql",
+  }
+
   if $archiver {
     # If barman archiver is enabled, export the ssh key of postgres user
     # into barman

--- a/spec/classes/barman_spec.rb
+++ b/spec/classes/barman_spec.rb
@@ -26,6 +26,8 @@ describe 'barman' do
 
   # Creates barman home and launches 'barman check all'
   it { is_expected.to contain_file('/var/lib/barman') }
+  it { is_expected.to contain_file('/var/lib/barman/.ssh').with_ensure('directory') }
+  it { is_expected.to contain_file('/var/lib/barman/.ssh/known_hosts') }
   it { is_expected.to contain_exec('barman-check-all') }
 
   # Creates the new home and launches barman check all
@@ -37,6 +39,8 @@ describe 'barman' do
     end
 
     it { is_expected.to contain_file('/srv/barman').with_ensure('directory') }
+    it { is_expected.to contain_file('/srv/barman/.ssh').with_ensure('directory') }
+    it { is_expected.to contain_file('/srv/barman/.ssh/known_hosts') }
     it { is_expected.to contain_exec('barman-check-all') }
   end
 


### PR DESCRIPTION
Barman backups will fail until SSH Host keys will be exchanged manually. 

Host keys can be exported an collected on the barman server and the PostgreSQL machines. 

Glad to improve this PR if something is not alright. 

