### PR TITLE
Improve handling of pg_hba_rule (fixes #38)

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -377,8 +377,8 @@ define barman::server (
   if($barman::autoconfigure) {
     # export configuration for the pg_hba.conf
     if ($streaming_archiver or $backup_method == 'postgres') {
-      @@postgresql::server::pg_hba_rule { "barman ${::hostname} client access (replication)":
-        description => "barman ${::hostname} client access",
+      @@postgresql::server::pg_hba_rule { "barman ${::hostname}->${name} client access (replication)":
+        description => "barman ${::hostname}->${name} client access",
         type        => 'host',
         database    => 'replication',
         user        => $barman::settings::dbuser,
@@ -387,8 +387,8 @@ define barman::server (
         tag         => "barman-${barman::host_group}",
       }
     }
-    @@postgresql::server::pg_hba_rule { "barman ${::hostname} client access":
-      description => "barman ${::hostname} client access",
+    @@postgresql::server::pg_hba_rule { "barman ${::hostname}->${name} client access":
+      description => "barman ${::hostname}->${name} client access",
       type        => 'host',
       database    => $barman::settings::dbname,
       user        => $barman::settings::dbuser,

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,6 @@
   "description": "Automates Barman installation and server setup",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=4.6.0 <5.0.0"},
-    {"name":"puppetlabs/postgresql","version_requirement":">=4.0.0 <5.0.0"}
+    {"name":"puppetlabs/postgresql","version_requirement":">=5.0.0 <6.0.0"}
   ]
 }


### PR DESCRIPTION
This PR is mainly about improving the handling of `pg_hba_rule`s.
It changes the resource collection in `barman::postgres` to only realize `pg_hba_rule` resources which were (indirectly) exported by the class itself. This fixes #38.

Also included is a small commit bumping the dependency on [puppetlabs/puppetlabs-postgresql](/puppetlabs/puppetlabs-postgresql) (fixes #46). This seems to have no negative side-effects, and was needed while testing the PR, but I can remove it, if it causes any issues I haven't seen.