### PR TITLE
extend validation of backup_options

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,7 +29,8 @@
 #                     rsync command. If set to postgres barman will use the
 #                     pg_basebackup command to execute the backup.
 # [*backup_options*] - Behavior for backup operations: possible values are
-#                      exclusive_backup (default) and concurrent_backup.
+#                      exclusive_backup (default) and concurrent_backup with optional
+#                      external_configuration.
 # [*recovery_options*] - The restore command to write in the recovery.conf.
 #                        Possible values are 'get-wal' and undef. Default: undef.
 # [*bandwidth_limit*] - This option allows you to specify a maximum transfer rate
@@ -249,7 +250,7 @@ define barman::server (
   validate_re($ensure, '^(present|absent)$', "${ensure} is not a valid value (ensure = present|absent).")
 
   # check if backup_options has correct values
-  validate_re($backup_options, [ '^exclusive_backup$', '^concurrent_backup$', 'Invalid backup option please use exclusive_backup or concurrent_backup' ])
+  validate_re($backup_options, [ '^(exclusive_backup|concurrent_backup)(,external_configuration)?$', 'Invalid backup option please use exclusive_backup or concurrent_backup with optional external_configuration' ])
 
   if($recovery_options) {
     # Check if recovery has correct values, if specified

--- a/spec/defines/server_spec.rb
+++ b/spec/defines/server_spec.rb
@@ -75,4 +75,29 @@ describe 'barman::server', :type => :define do
     }
   end
 
+  context "with valid backup_options => exclusive_backup" do
+    let(:params) { @defaults.merge({ :backup_options => 'exclusive_backup' }) }
+    it { is_expected.to compile }
+  end
+
+  context "with valid backup_options => concurrent_backup" do
+    let(:params) { @defaults.merge({ :backup_options => 'concurrent_backup' }) }
+    it { is_expected.to compile }
+  end
+
+  context "with valid backup_options => exclusive_backup,external_configuration" do
+    let(:params) { @defaults.merge({ :backup_options => 'exclusive_backup,external_configuration' }) }
+    it { is_expected.to compile }
+  end
+
+  context "with valid backup_options => concurrent_backup,external_configuration" do
+    let(:params) { @defaults.merge({ :backup_options => 'concurrent_backup,external_configuration' }) }
+    it { is_expected.to compile }
+  end
+
+  context "with invalid backup_options => external_configuration" do
+    let(:params) { @defaults.merge({ :backup_options => 'external_configuration' }) }
+    it { is_expected.to compile.and_raise_error(/Invalid backup option please use exclusive_backup or concurrent_backup with optional external_configuration/) }
+  end
+
 end


### PR DESCRIPTION
Allow usage of external_configuration in combination with exclusive_backup and concurrent_backup