### PR TITLE
disable archive mode when archiver is disabled

### DIFF
--- a/manifests/postgres.pp
+++ b/manifests/postgres.pp
@@ -299,9 +299,14 @@ class barman::postgres (
     default => $password,
   }
 
+  $archive_mode = $archiver ? {
+    true  => 'on',
+    false => 'off',
+  }
+
   # Configure PostgreSQL server for archive mode
   postgresql::server::config_entry {
-    'archive_mode': value => 'on';
+    'archive_mode': value => $archive_mode;
     'wal_level': value => $wal_level;
   }
 

--- a/manifests/postgres.pp
+++ b/manifests/postgres.pp
@@ -301,7 +301,7 @@ class barman::postgres (
 
   $archive_mode = $archiver ? {
     true  => 'on',
-    false => 'off',
+    default => 'off',
   }
 
   # Configure PostgreSQL server for archive mode


### PR DESCRIPTION
With disabled archiver WAL logs would just fill up all disk space on the DB node.